### PR TITLE
Fix broken links in deck.html

### DIFF
--- a/deck_of_cards/_nbdev.py
+++ b/deck_of_cards/_nbdev.py
@@ -8,8 +8,8 @@ index = {"Card": "00_card.ipynb",
 modules = ["card.py",
            "deck.py"]
 
-doc_url = "https://hamelsmu.github.io/deck_of_cards/"
+doc_url = "https://fastai.github.io/deck_of_cards/"
 
-git_url = "https://github.com/hamelsmu/deck_of_cards/tree/master/"
+git_url = "https://github.com/fastai/deck_of_cards/tree/master/"
 
 def custom_doc_links(name): return None

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-repository: hamelsmu/deck_of_cards
+repository: fastai/deck_of_cards
 output: web
 topnav_title: deck_of_cards
 site_title: deck_of_cards
@@ -20,7 +20,7 @@ exclude:
   - .idea/
   - .gitignore
   - vendor
- 
+
 exclude: [vendor]
 
 highlighter: rouge

--- a/docs/card.html
+++ b/docs/card.html
@@ -21,16 +21,16 @@ nb_path: "00_card.ipynb"
 -->
 
 <div class="container" id="notebook-container">
-        
+
     {% raw %}
-    
+
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
     {% endraw %}
 
     {% raw %}
-    
+
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -40,7 +40,7 @@ nb_path: "00_card.ipynb"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h2 id="Card" class="doc_header"><code>class</code> <code>Card</code><a href="https://github.com/hamelsmu/deck_of_cards/tree/master/deck_of_cards/card.py#L15" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>Card</code>(<strong><code>suit</code></strong>=<em><code>0</code></em>, <strong><code>rank</code></strong>=<em><code>2</code></em>)</p>
+<h2 id="Card" class="doc_header"><code>class</code> <code>Card</code><a href="https://github.com/fastai/deck_of_cards/tree/master/deck_of_cards/card.py#L15" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>Card</code>(<strong><code>suit</code></strong>=<em><code>0</code></em>, <strong><code>rank</code></strong>=<em><code>2</code></em>)</p>
 </blockquote>
 <p>Represents a standard playing card.</p>
 <p>Attributes:
@@ -58,7 +58,7 @@ nb_path: "00_card.ipynb"
     {% endraw %}
 
     {% raw %}
-    
+
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
@@ -72,7 +72,7 @@ nb_path: "00_card.ipynb"
 </div>
 </div>
     {% raw %}
-    
+
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -105,7 +105,7 @@ nb_path: "00_card.ipynb"
     {% endraw %}
 
     {% raw %}
-    
+
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -133,7 +133,7 @@ nb_path: "00_card.ipynb"
 </div>
 </div>
     {% raw %}
-    
+
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -164,7 +164,7 @@ nb_path: "00_card.ipynb"
 </div>
 </div>
     {% raw %}
-    
+
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -189,7 +189,7 @@ nb_path: "00_card.ipynb"
     {% endraw %}
 
     {% raw %}
-    
+
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -208,5 +208,3 @@ nb_path: "00_card.ipynb"
     {% endraw %}
 
 </div>
- 
-

--- a/docs/deck.html
+++ b/docs/deck.html
@@ -21,23 +21,23 @@ nb_path: "01_deck.ipynb"
 -->
 
 <div class="container" id="notebook-container">
-        
+
     {% raw %}
-    
+
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
     {% endraw %}
 
     {% raw %}
-    
+
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
     {% endraw %}
 
     {% raw %}
-    
+
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -47,7 +47,7 @@ nb_path: "01_deck.ipynb"
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h2 id="Deck" class="doc_header"><code>class</code> <code>Deck</code><a href="https://github.com/hamelsmu/deck_of_cards/tree/master/deck_of_cards/deck.py#L9" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>Deck</code>()</p>
+<h2 id="Deck" class="doc_header"><code>class</code> <code>Deck</code><a href="https://github.com/fastai/deck_of_cards/tree/master/deck_of_cards/deck.py#L9" class="source_link" style="float:right">[source]</a></h2><blockquote><p><code>Deck</code>()</p>
 </blockquote>
 <p>Represents a deck of cards.
 Attributes:
@@ -64,7 +64,7 @@ Attributes:
     {% endraw %}
 
     {% raw %}
-    
+
 <div class="cell border-box-sizing code_cell rendered">
 
 </div>
@@ -78,7 +78,7 @@ Attributes:
 </div>
 </div>
     {% raw %}
-    
+
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -96,7 +96,7 @@ Attributes:
     {% endraw %}
 
     {% raw %}
-    
+
 <div class="cell border-box-sizing code_cell rendered">
 
 <div class="output_wrapper">
@@ -106,7 +106,7 @@ Attributes:
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="Deck.remove_card" class="doc_header"><code>Deck.remove_card</code><a href="https://github.com/hamelsmu/deck_of_cards/tree/master/deck_of_cards/deck.py#L38" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>Deck.remove_card</code>(<strong><code>card</code></strong>)</p>
+<h4 id="Deck.remove_card" class="doc_header"><code>Deck.remove_card</code><a href="https://github.com/fastai/deck_of_cards/tree/master/deck_of_cards/deck.py#L38" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>Deck.remove_card</code>(<strong><code>card</code></strong>)</p>
 </blockquote>
 <p>Removes a card from the deck or raises exception if it is not there.</p>
 <p>card: Card</p>
@@ -129,7 +129,7 @@ Attributes:
 </div>
 </div>
     {% raw %}
-    
+
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -156,7 +156,7 @@ Attributes:
 </div>
 </div>
     {% raw %}
-    
+
 <div class="cell border-box-sizing code_cell rendered">
 <div class="input">
 
@@ -191,5 +191,3 @@ Attributes:
     {% endraw %}
 
 </div>
- 
-

--- a/settings.ini
+++ b/settings.ini
@@ -6,7 +6,7 @@ lib_name = deck_of_cards
 # repo_name = analytics
 # company_name = nike
 
-user = hamelsmu
+user = fastai
 description = "A minimal example of nbdev using code from Allen Downey's Think Python 2nd Ed"
 keywords = nbdev
 author = Hamel Husain
@@ -24,11 +24,11 @@ license = apache2
 # From 1-7: Planning Pre-Alpha Alpha Beta Production Mature Inactive
 status = 2
 # Optional. Same format as setuptools requirements
-# requirements = 
+# requirements =
 # Optional. Same format as setuptools console_scripts
-# console_scripts = 
+# console_scripts =
 # Optional. Same format as setuptools dependency-links
-# dep_links = 
+# dep_links =
 ###
 # You probably won't need to change anything under here,
 #   unless you have some special requirements
@@ -40,8 +40,8 @@ doc_path = docs
 
 # Anything shown as '%(...)s' is substituted with that setting automatically
 doc_host =  https://%(user)s.github.io
-#For Enterprise Git pages use:  
-#doc_host = https://pages.github.%(company_name)s.com.  
+#For Enterprise Git pages use:
+#doc_host = https://pages.github.%(company_name)s.com.
 
 
 doc_baseurl = /%(lib_name)s/
@@ -61,10 +61,10 @@ title = %(lib_name)s
 #Monospace docstings: adds <pre> tags around the doc strings, preserving newlines/indentation.
 #monospace_docstrings = False
 #Test flags: introduce here the test flags you want to use separated by |
-#tst_flags = 
+#tst_flags =
 #Custom sidebar: customize sidebar.json yourself for advanced sidebars (False/True)
-#custom_sidebar = 
+#custom_sidebar =
 #Cell spacing: if you want cell blocks in code separated by more than one new line
-#cell_spacing = 
+#cell_spacing =
 #Custom jekyll styles: if you want more jekyll styles than tip/important/warning, set them here
 #jekyll_styles = note,warning,tip,important


### PR DESCRIPTION
A patch for broken links on the page https://fastai.github.io/deck_of_cards/deck.html#Deck

Links to deck_of_cards repository of `fastai` were pointing to a non-existing repo with the same name under user `hamelsmu`. Broken links were fixed as per issue #1  